### PR TITLE
fix typo

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -642,7 +642,7 @@ bot.on('message', async (message) => {
                         // the meat and potatoes of the embed
                         parseEntities(triviaData[i].question) + // the question
                             '\n' + // added a space
-                            '\n**Choices**' + // added a space
+                            '\n**Choices:**' + // added a space
                             '\n' +
                             '\n🇦 ' +
                             parseEntities(choices[0]) + // outputs the choices from the array 'choices'


### PR DESCRIPTION
All I did was add a colon after `Choices` in the `-play mc competitive` game because it was bothering me that it wasn't consistent with the other games. ﻿
