### PR TITLE
Added shorter aliases to competitive commands

### DIFF
--- a/src/Commands/mccompetitive.js
+++ b/src/Commands/mccompetitive.js
@@ -6,7 +6,7 @@ import { MessageEmbed } from 'discord.js';
 export default class extends Command {
     constructor(...args) {
         super(...args, {
-            aliases: ['mccompetitive', 'mcompetitive'],
+            aliases: ['mccompetitive', 'mcompetitive', 'mccomp', 'mcomp'],
             description:
                 'Initiates a round of 10 question Multiple Choice trivia with random difficulties and random categories. Its `competitive` because this will only accept the first person that guesses correctly; everyone else loses by default. **TLDR; you have to be the first to answer correctly!**',
             category: 'Game Modes',

--- a/src/Commands/tfcompetitive.js
+++ b/src/Commands/tfcompetitive.js
@@ -6,6 +6,7 @@ import { MessageEmbed } from 'discord.js';
 export default class extends Command {
     constructor(...args) {
         super(...args, {
+            aliases: ['tfcompetitive', 'tfcomp'],
             description:
                 'Initiates a round of 10 question T/F trivia with random difficulties and random categories. Its `competitive` because this will only accept the first person that guesses correctly; everyone else loses by default. **TLDR; you have to be the first to answer correctly!**',
             category: 'Game Modes',


### PR DESCRIPTION
# Description

The competitive commands have pretty long names, so this adds aliases for them using a common abbreviation. Just something that was at the back at my mind while working on my last PR.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
